### PR TITLE
feat: create config file on sign-up

### DIFF
--- a/src/commands/sign-up/index.ts
+++ b/src/commands/sign-up/index.ts
@@ -10,7 +10,7 @@ import {
 import { userManagementService } from '../../services'
 import { CliError, WrongEmailError, getErrorOutput } from '../../errors'
 import { WelcomeUserStyledMessage } from '../../render/functions'
-import { createSession, parseJwt } from '../../services/user-management'
+import { createConfig, createSession, parseJwt } from '../../services/user-management'
 import { EventDTO } from '../../services/analytics/analytics.api'
 import { analyticsService, generateUserMetadata } from '../../services/analytics'
 
@@ -69,6 +69,7 @@ export default class SignUp extends Command {
     const { userId } = parseJwt(sessionToken.slice('console_authtoken='.length))
 
     createSession(email, userId, sessionToken)
+    createConfig({ userId })
 
     const analyticsData: EventDTO = {
       name: 'CONSOLE_USER_SIGN_UP',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+const fs = require('fs')
+
+export const { version } = JSON.parse(fs.readFileSync('package.json', 'utf8'))

--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -1,0 +1,111 @@
+import Conf from 'conf'
+import * as os from 'os'
+import * as path from 'path'
+
+import { version } from '../../constants'
+
+export const getMajorVersion = (): number => {
+  return parseInt(version[0], 10)
+}
+
+type UserId = string
+
+type UserConfig = {
+  activeProjectId: string
+  outputFormat: string
+}
+
+type ConfigStoreFormat = {
+  version: number
+  currentUserId: string
+  configs: Record<UserId, UserConfig>
+}
+
+interface IConfigStorer {
+  save(params: ConfigStoreFormat): void
+  // clear(): void
+  getVersion: () => number
+  getCurrentUser: () => string
+  getAllUserConfigs: () => Record<UserId, UserConfig>
+}
+
+class ConfigService {
+  private readonly store: IConfigStorer
+
+  constructor(store: IConfigStorer) {
+    this.store = store
+  }
+
+  public getVersion = (): number => {
+    return this.store.getVersion()
+  }
+
+  public show = (): ConfigStoreFormat => {
+    const currentUserId = this.store.getCurrentUser()
+    const configVersion = this.store.getVersion()
+    const configs = this.store.getAllUserConfigs()
+    return { version: configVersion, currentUserId, configs }
+  }
+
+  public create = (userId: string): void => {
+    this.store.save({
+      currentUserId: userId,
+      version: getMajorVersion(),
+      configs: {
+        [userId]: {
+          activeProjectId: '',
+          outputFormat: 'plaintext',
+        },
+      },
+    })
+  }
+}
+
+const configConf = new Conf({
+  cwd: path.join(os.homedir(), '.affinidi'),
+  configName: 'config',
+})
+
+const store: IConfigStorer = {
+  save: (params: ConfigStoreFormat): void => {
+    // TODO validate the config before saving
+    configConf.set('version', params.version)
+    configConf.set('currentUserID', params.currentUserId)
+    configConf.set('configs', params.configs)
+  },
+
+  getVersion: (): number | null => {
+    const v = Number(configConf.get('version'))
+    return Number.isNaN(v) ? null : v
+  },
+
+  getCurrentUser: (): string => {
+    const value = configConf.get('currentUserID')
+    return typeof value === 'string' ? value : ''
+  },
+
+  getAllUserConfigs: (): Record<string, UserConfig> => {
+    throw new Error('Function not implemented.')
+  },
+}
+
+export const testStore = new Map()
+const testStorer: IConfigStorer = {
+  save: (params: ConfigStoreFormat): void => {
+    testStore.set('version', params.version)
+    testStore.set('currentUserID', params.currentUserId)
+    testStore.set('configs', params.configs)
+  },
+  getVersion: (): number => {
+    return testStore.get('version')
+  },
+
+  getCurrentUser: (): string => {
+    return testStore.get('currentUserID')
+  },
+  getAllUserConfigs: (): Record<string, UserConfig> => {
+    return testStore.get('configs')
+  },
+}
+
+export const configService = new ConfigService(process.env.NODE_ENV === 'test' ? testStorer : store)

--- a/src/services/user-management/index.ts
+++ b/src/services/user-management/index.ts
@@ -5,6 +5,7 @@ import { StatusCodes } from 'http-status-codes'
 import { Api as UserManagementApi } from './user-management.api'
 import { CliError } from '../../errors'
 import { vaultService, VAULT_KEYS } from '../vault'
+import { configService } from '../config'
 
 type SessionToken = string
 type AuthFlow = 'login' | 'signup'
@@ -50,6 +51,10 @@ export const createSession = (
   }
   vaultService.set(VAULT_KEYS.session, JSON.stringify(session))
   return session
+}
+
+export const createConfig = ({ userId }: { userId: string }): void => {
+  configService.create(userId)
 }
 
 class UserManagementService {

--- a/src/services/vault/index.ts
+++ b/src/services/vault/index.ts
@@ -10,8 +10,6 @@ export const VAULT_KEYS = {
   session: 'session',
 }
 
-const doNothing = () => {}
-
 interface IVaultSetterGetter {
   clear: () => void
   delete: (key: string) => void
@@ -20,27 +18,27 @@ interface IVaultSetterGetter {
 }
 
 class VaultService {
-  private readonly storer: IVaultSetterGetter
+  private readonly store: IVaultSetterGetter
 
   constructor(storer: IVaultSetterGetter) {
-    this.storer = storer
+    this.store = storer
   }
 
   public clear = (): void => {
-    this.storer.clear()
+    this.store.clear()
   }
 
   public delete = (key: string): void => {
-    this.storer.delete(key)
+    this.store.delete(key)
   }
 
   public get = (key: string): string | null => {
-    const value = this.storer.get(key)
+    const value = this.store.get(key)
     return typeof value === 'string' ? value : null
   }
 
   public set = (key: string, value: string): void => {
-    this.storer.set(key, value)
+    this.store.set(key, value)
   }
 }
 
@@ -62,7 +60,8 @@ const testStorer: IVaultSetterGetter = {
 }
 
 const credentialConf = new Conf({
-  cwd: path.join(os.homedir(), '.affinidi', 'credentials'),
+  cwd: path.join(os.homedir(), '.affinidi'),
+  configName: 'credentials',
 })
 
 const storer: IVaultSetterGetter = {

--- a/test/commands/sign-up/index.test.ts
+++ b/test/commands/sign-up/index.test.ts
@@ -7,12 +7,22 @@ import { WrongEmailError } from '../../../src/errors'
 import { USER_MANAGEMENT_URL } from '../../../src/services/user-management'
 import * as prompts from '../../../src/user-actions'
 import { ANALYTICS_URL } from '../../../src/services/analytics'
+import { vaultService } from '../../../src/services'
+import { configService, getMajorVersion, testStore } from '../../../src/services/config'
 
 const validEmailAddress = 'valid@email-address.com'
 const validCookie =
   'console_authtoken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIzOGVmY2M3MC1iYmUxLTQ1N2EtYTZjNy1iMjlhZDk5MTM2NDgiLCJ1c2VybmFtZSI6InZhbGlkQGVtYWlsLWFkZHJlc3MuY29tIiwiYWNjZXNzVG9rZW4iOiJtb2NrZWQtYWNjZXNzLXRva2VuIiwiZXhwIjoxNjY4MDA0Njk3LCJpYXQiOjE2Njc5MTgyOTd9.WDOeDB6PwFkmXWhe4zmMnltJGB44ayvDYaHDKJlcZEQ; Domain=affinidi.com; Path=/; Expires=Wed, 09 Nov 2022 14:38:17 GMT; HttpOnly; Secure; SameSite=Lax'
+const testUserId = '38efcc70-bbe1-457a-a6c7-b29ad9913648'
 const testOTP = '123456'
 const doNothing = () => {}
+
+const clearSessionAndConfig = () => {
+  vaultService.clear()
+  testStore.clear()
+}
+
+after(clearSessionAndConfig)
 
 describe('sign-up command', () => {
   test
@@ -37,28 +47,38 @@ describe('sign-up command', () => {
         })
     })
 
-    test
-      .nock(`${USER_MANAGEMENT_URL}`, (api) =>
-        api.post('/auth/signup').reply(StatusCodes.OK, { token: 'some-valid-token' }),
-      )
-      .nock(`${USER_MANAGEMENT_URL}`, (api) =>
-        api
-          .post('/auth/signup/confirm')
-          .reply(StatusCodes.OK, null, { 'set-cookie': [validCookie] }),
-      )
-      .nock(`${ANALYTICS_URL}`, (api) => api.post('/api/events').reply(StatusCodes.CREATED))
-      .stdout()
-      .stub(prompts, 'enterEmailPrompt', () => async () => validEmailAddress)
-      .stub(prompts, 'acceptConditionsAndPolicy', () => async () => prompts.AnswerYes)
-      .stub(prompts, 'enterOTPPrompt', () => async () => testOTP)
-      .stub(CliUx.ux.action, 'start', () => () => doNothing)
-      .stub(CliUx.ux.action, 'stop', () => doNothing)
-      .command(['sign-up'])
-      .it('runs sign-up and shows a welcome message', (ctx) => {
-        const output = ctx.stdout
-        getWelcomeUserRawMessages().forEach((b) => {
-          expect(output).to.contain(b)
+    describe('When user accepts the conditions and policy', () => {
+      before(clearSessionAndConfig)
+      test
+        .nock(`${USER_MANAGEMENT_URL}`, (api) =>
+          api.post('/auth/signup').reply(StatusCodes.OK, { token: 'some-valid-token' }),
+        )
+        .nock(`${USER_MANAGEMENT_URL}`, (api) =>
+          api
+            .post('/auth/signup/confirm')
+            .reply(StatusCodes.OK, null, { 'set-cookie': [validCookie] }),
+        )
+        .nock(`${ANALYTICS_URL}`, (api) => api.post('/api/events').reply(StatusCodes.CREATED))
+        .stdout()
+        .stub(prompts, 'enterEmailPrompt', () => async () => validEmailAddress)
+        .stub(prompts, 'acceptConditionsAndPolicy', () => async () => prompts.AnswerYes)
+        .stub(prompts, 'enterOTPPrompt', () => async () => testOTP)
+        .stub(CliUx.ux.action, 'start', () => () => doNothing)
+        .stub(CliUx.ux.action, 'stop', () => doNothing)
+        .command(['sign-up'])
+        .it('runs sign-up and shows a welcome message', (ctx) => {
+          const output = ctx.stdout
+          getWelcomeUserRawMessages().forEach((b) => {
+            expect(output).to.contain(b)
+          })
+
+          const config = configService.show()
+          expect(config.currentUserId).to.equal(testUserId)
+          expect(config.version).to.equal(getMajorVersion())
+          expect(config.configs).to.haveOwnProperty(testUserId)
+          expect(config.configs[testUserId].activeProjectId).to.equal('')
+          expect(config.configs[testUserId].outputFormat).to.equal('plaintext')
         })
-      })
+    })
   })
 })


### PR DESCRIPTION
This PR adds a functionality that consists of creating a config file on sign-up with default values.

It looks like this
```json
{
	"version": 1,
	"currentUserID": "5712433a-a15b-4224-ae3f-35859850414a",
	"configs": {
		"5712433a-a15b-4224-ae3f-35859850414a": {
			"activeProjectId": "",
			"outputFormat": "plaintext"
		}
	}
}
```

The tests use an in-memory store for test.