### PR TITLE
feat: generate reference app with proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ Use this command to generate a Privacy Preserving app
 
 USAGE
 ```
-$ affinidi generate-application [-p web|mobile] [-n <value>] [-u portable-reputation|access-without-ownership-of-data|certification-and-verification|kyc-kyb]
+$ affinidi generate-application [-p web|mobile] [-n <value>] [-u portable-reputation|access-without-ownership-of-data|certification-and-verification|kyc-kyb] [-w]
 
 FLAGS
 -n, --name=<value>                                                                                            [default: my-app] Name of the application
 -p, --platform=(web|mobile)                                                                                   [default: web] Platform
 -u, --use-case=(portable-reputation|access-without-ownership-of-data|certification-and-verification|kyc-kyb)  [default: certification-and-verification] Use case
+-w, --with-proxy                                                                                              Add backend-proxy to protect credentials
 
 DESCRIPTION
 Use this command to generate a Privacy Preserving app

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/affinityproject/affinidi-cli.git"
+    "url": "git+https://github.com/affinidi/affinidi-cli.git"
   },
   "keywords": [
     "affinidi",
@@ -47,9 +47,9 @@
     "oclif"
   ],
   "bugs": {
-    "url": "https://github.com/affinityproject/affinidi-cli/issues"
+    "url": "https://github.com/affinidi/affinidi-cli/issues"
   },
-  "homepage": "https://github.com/affinityproject/affinidi-cli#readme",
+  "homepage": "https://github.com/affinidi/affinidi-cli#readme",
   "dependencies": {
     "@oclif/core": "^1.20.4",
     "@oclif/plugin-help": "^5.1.16",

--- a/src/commands/generate-application/index.ts
+++ b/src/commands/generate-application/index.ts
@@ -173,7 +173,7 @@ export default class GenerateApplication extends Command {
           'FRONTEND_HOST=http://localhost:3000',
 
           `API_KEY_HASH=${activeProjectApiKey}`,
-          `PROJECT_DID=${activeProjectDid}`,
+          `ISSUER_DID=${activeProjectDid}`,
           `PROJECT_ID=${activeProjectId}`,
         ])
 

--- a/src/commands/generate-application/index.ts
+++ b/src/commands/generate-application/index.ts
@@ -33,7 +33,7 @@ const UseCaseSources: Record<UseCaseType, string> = {
   'portable-reputation': 'NOT IMPLEMENTED YET',
   'access-without-ownership-of-data': 'NOT IMPLEMENTED YET',
   'certification-and-verification':
-    'https://github.com/affinityproject/elements-reference-app-frontend.git',
+    'https://github.com/affinidi/elements-reference-app-frontend.git',
   'kyc-kyb': 'NOT IMPLEMENTED YET',
 }
 
@@ -41,7 +41,7 @@ export const defaultAppName = 'my-app'
 export default class GenerateApplication extends Command {
   static command = 'affinidi generate-application'
 
-  static usage = 'affinidi generate-application [FLAGS]'
+  static usage = 'generate-application [FLAGS]'
 
   static description = 'Use this command to generate a Privacy Preserving app'
 
@@ -65,11 +65,16 @@ export default class GenerateApplication extends Command {
       default: 'certification-and-verification',
       options: Object.values(UseCasesAppNames),
     }),
+    'with-proxy': Flags.boolean({
+      char: 'w',
+      description: 'Add BE-proxy to protect credentials',
+      default: false,
+    }),
   }
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GenerateApplication)
-    const { name, platform, 'use-case': useCase } = flags
+    const { name, platform, 'use-case': useCase, 'with-proxy': withProxy } = flags
     const session = getSession()
     const analyticsData: EventDTO = {
       name: 'APPLICATION_GENERATION_STARTED',
@@ -107,13 +112,25 @@ export default class GenerateApplication extends Command {
       CliUx.ux.error(`Failed to generate an application: ${error.message}`)
     }
 
-    this.setUpProject(name)
+    try {
+      if (withProxy) {
+        await this.download(
+          'https://github.com/affinidi/elements-reference-app-backend.git',
+          `${name}-backend`,
+        )
+      }
+    } catch (error) {
+      CliUx.ux.info(`Failed to generate an application: ${error.message}`)
+      return
+    }
+
+    this.setUpProject(name, withProxy)
     analyticsData.name = 'APPLICATION_GENERATION_COMPLETED'
     await analyticsService.eventsControllerSend(analyticsData)
-    CliUx.ux.action.stop('Application generated')
+    CliUx.ux.action.stop('\nApplication generated')
 
-    const appPath = `${process.cwd()}/${name}`
-    CliUx.ux.info(buildGeneratedAppNextStepsMessage(name, appPath))
+    const appPath = path.resolve(`${process.cwd()}/${name}`)
+    CliUx.ux.info(buildGeneratedAppNextStepsMessage(name, appPath, withProxy))
   }
 
   async catch(error: CliError) {
@@ -128,7 +145,7 @@ export default class GenerateApplication extends Command {
     )
   }
 
-  private setUpProject(name: string) {
+  private setUpProject(name: string, withProxy: boolean) {
     const activeProjectApiKey = vaultService.get('active-project-api-key')
     const activeProjectDid = vaultService.get('active-project-did')
     const activeProjectId = vaultService.get('active-project-id')
@@ -140,6 +157,29 @@ export default class GenerateApplication extends Command {
     CliUx.ux.info(`Setting up the project`)
 
     try {
+      if (withProxy) {
+        Writer.write(path.join(name, '.env'), [
+          'REACT_APP_CLOUD_WALLET_URL=http://localhost:8080/cloud-wallet',
+          'REACT_APP_VERIFIER_URL=http://localhost:8080/affinity-verifier',
+          'REACT_APP_USER_MANAGEMENT_URL=http://localhost:8080/user-management',
+          'REACT_APP_ISSUANCE_URL=http://localhost:8080/console-vc-issuance',
+        ])
+
+        Writer.write(path.join(`${name}-backend`, '.env'), [
+          'HOST=127.0.0.1',
+          'PORT=8080',
+          'NODE_ENV=dev',
+          'ENVIRONMENT=development',
+          'FRONTEND_HOST=http://localhost:3000',
+
+          `API_KEY_HASH=${activeProjectApiKey}`,
+          `PROJECT_DID=${activeProjectDid}`,
+          `PROJECT_ID=${activeProjectId}`,
+        ])
+
+        return
+      }
+
       Writer.write(path.join(name, '.env'), [
         'REACT_APP_CLOUD_WALLET_URL=https://cloud-wallet-api.prod.affinity-project.org',
         'REACT_APP_VERIFIER_URL=https://affinity-verifier.prod.affinity-project.org',

--- a/src/render/texts.ts
+++ b/src/render/texts.ts
@@ -22,7 +22,7 @@ export const buildInvalidCommandUsage = (
     hint ? ` (${hint.join(',')})` : ''
   }.
   See "${command} --help"
-  
+
   Usage: ${chalk.bold(`$ affinidi ${usage}`)}
 
   ${summary}
@@ -51,25 +51,41 @@ export const useCommandDescription = chalk`
 export const buildGeneratedAppNextStepsMessageBlocks = (
   name: string,
   appPath: string,
+  withProxy: boolean,
 ): { text: string; styled: string }[] => {
   return [
     {
       text: `Successfully generated ${name} at ${appPath}`,
       styled: `${chalk.green('Successfully')} generated ${chalk.italic(name)} at ${appPath}`,
     },
-    {
-      text: 'cd inside of this directory and install the dependencies fist by installing the dependencies',
-      styled:
-        'cd inside of this directory and install the dependencies fist by installing the dependencies',
+    withProxy && {
+      text: `Successfully generated ${name}-backend at ${appPath}-backend`,
+      styled: `${chalk.green('Successfully')} generated ${chalk.italic(
+        `${name}-backend`,
+      )} at ${appPath}-backend`,
     },
+    withProxy
+      ? {
+          text: 'open each directory in separate terminals and install the dependencies',
+          styled: 'open each directory in separate terminals and install the dependencies',
+        }
+      : {
+          text: 'open this directory in terminal and install the dependencies',
+          styled: 'open this directory in terminal and install the dependencies',
+        },
     {
       text: '$ npm install',
       styled: `  ${chalk.bgWhite('$ npm install')}`,
     },
-    {
-      text: 'then start the application with the command:',
-      styled: 'then start the application with the command:',
-    },
+    withProxy
+      ? {
+          text: 'then start both applications with the command:',
+          styled: 'then start both applications with the command:',
+        }
+      : {
+          text: 'then start the application with the command:',
+          styled: 'then start the application with the command:',
+        },
     {
       text: '$ npm run start',
       styled: `  ${chalk.bgWhite('$ npm run start')}`,
@@ -78,11 +94,15 @@ export const buildGeneratedAppNextStepsMessageBlocks = (
       text: 'Enjoy the App!',
       styled: 'Enjoy the App!',
     },
-  ]
+  ].filter((item) => !!item)
 }
 
-export const buildGeneratedAppNextStepsMessage = (name: string, appPath: string): string => {
-  return buildGeneratedAppNextStepsMessageBlocks(name, appPath)
+export const buildGeneratedAppNextStepsMessage = (
+  name: string,
+  appPath: string,
+  withProxy: boolean,
+): string => {
+  return buildGeneratedAppNextStepsMessageBlocks(name, appPath, withProxy)
     .map((b) => b.styled)
     .join('\n\n')
 }

--- a/test/commands/generate-application/index.test.ts
+++ b/test/commands/generate-application/index.test.ts
@@ -81,6 +81,7 @@ describe('generate-application command', () => {
           buildGeneratedAppNextStepsMessageBlocks(
             defaultAppName,
             `${process.cwd()}/${defaultAppName}`,
+            false,
           )
             .map((b) => b.text)
             .forEach((msg) => {
@@ -88,5 +89,28 @@ describe('generate-application command', () => {
             })
         })
     })
+  })
+
+  describe('Given -w (backend proxy)', () => {
+    test
+      .nock(`${ANALYTICS_URL}`, (api) => api.post('/api/events').reply(StatusCodes.CREATED))
+      .nock(`${ANALYTICS_URL}`, (api) => api.post('/api/events').reply(StatusCodes.CREATED))
+      .stdout()
+      .stub(GitService, 'clone', doNothing)
+      .stub(Writer, 'write', doNothing)
+      .stub(CliUx.ux.action, 'start', () => () => doNothing)
+      .stub(CliUx.ux.action, 'stop', () => doNothing)
+      .command(['generate-application', '-w'])
+      .it('it runs generate-application and shows the next steps long description', (ctx) => {
+        buildGeneratedAppNextStepsMessageBlocks(
+          defaultAppName,
+          `${process.cwd()}/${defaultAppName}`,
+          true,
+        )
+          .map((b) => b.text)
+          .forEach((msg) => {
+            expect(ctx.stdout).to.contain(msg)
+          })
+      })
   })
 })


### PR DESCRIPTION
# Context

This PR adds a BE-proxy, which hides all the credentials, hence FE doesn't need to send api-key and projectId&walletDid for issuer flow.

BE template is published on this repository: 

https://github.com/affinidi/elements-reference-app-backend

# How to test:

run (while being authenticated)

```
npm run dev generate-application -- -w
```
open created projects in two terminals and run 
```
npm start
```

