### PR TITLE
fix: add Accept-Encoding: application/json for axios

### DIFF
--- a/src/services/analytics/index.ts
+++ b/src/services/analytics/index.ts
@@ -25,6 +25,9 @@ class AnalyticsService {
     private readonly client = new AnalyticsApi({
       baseURL: ANALYTICS_URL,
       withCredentials: true,
+      headers: {
+        'Accept-Encoding': 'application/json',
+      },
     }),
   ) {}
 

--- a/src/services/iam/index.ts
+++ b/src/services/iam/index.ts
@@ -9,6 +9,9 @@ class IAmService {
     private readonly client = new IamApi({
       baseURL: IAM_URL,
       withCredentials: true,
+      headers: {
+        'Accept-Encoding': 'application/json',
+      },
     }),
   ) {}
 

--- a/src/services/issuance/index.ts
+++ b/src/services/issuance/index.ts
@@ -17,10 +17,16 @@ class IssuanceService {
     private readonly client = new IssuanceAPI({
       baseURL: ISSUANCE_URL,
       withCredentials: true,
+      headers: {
+        'Accept-Encoding': 'application/json',
+      },
     }),
     private readonly bulkClient = new BulkApi({
       baseURL: ISSUANCE_URL,
       withCredentials: true,
+      headers: {
+        'Accept-Encoding': 'application/json',
+      },
     }),
   ) {}
 

--- a/src/services/schema-manager/index.ts
+++ b/src/services/schema-manager/index.ts
@@ -13,6 +13,9 @@ class SchemaManagerService {
   constructor(
     private readonly client = new SchemaManagerApi({
       baseURL: SCHEMA_MANAGER_URL,
+      headers: {
+        'Accept-Encoding': 'application/json',
+      },
     }),
   ) {}
 

--- a/src/services/user-management/index.ts
+++ b/src/services/user-management/index.ts
@@ -62,6 +62,9 @@ class UserManagementService {
     private readonly client = new UserManagementApi({
       baseURL: USER_MANAGEMENT_URL,
       withCredentials: true,
+      headers: {
+        'Accept-Encoding': 'application/json',
+      },
     }),
   ) {}
 

--- a/src/services/verification/index.ts
+++ b/src/services/verification/index.ts
@@ -9,6 +9,9 @@ class VerifierService {
     private readonly client = new VerifierApi({
       baseURL: VERIFIER_URL,
       withCredentials: true,
+      headers: {
+        'Accept-Encoding': 'application/json',
+      },
     }),
   ) {}
 


### PR DESCRIPTION
services on affinity-project.org  by default send gziped response which breaks axios 