### PR TITLE
feat: update documentation for schema management and vc issuance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ affinidi create project
 affinidi generate-application -n "My application"
 ```
 
+### Issue a VC for an example schema
+
+- create a file vc.json:
+```
+{
+    "date": "2022-12-11T23:12:00Z",
+    "place": "Awesome Location",
+    "eventName": "Awesome Event",
+    "eventDescription": "Awesome Description",
+    "name": "John Snow",
+    "email": "mail@example.com"
+}
+```
+
+- run a command:
+```
+affinidi issue-vc <REPLACE WITH YOUR EMAIL> -s=https://schema.affinidi.com/TestSchemaV1-4.json -d=vc.json -w=https://holder-reference-app.stg.affinidi.com/holder
+```
+
+- find an email with credential subject and follow the link to view and claim a credential.
+
 ## Schema manager
 
 ### What is Schema manager?
@@ -94,7 +115,7 @@ However, you can always fork your private (unlisted) schema in order to make it 
 
 ### How to create a schema
 
-1 Prepare a json file with schema details:
+#### 1 Prepare a json file with schema details:
 
 ```
 {
@@ -135,13 +156,13 @@ Example:
 }
 ```
 
-2 Run a command:
+#### 2 Run a command:
 
 ```
 affinidi create schema -d <Description of your schema> -p=<true if private, false id public) -s=<schema.json>
 ```
 
-3 In the response you will receive "jsonSchemaUrl" which you should use to issue a verifiable credential.
+#### 3 In the response you will receive "jsonSchemaUrl" which you should use to issue a verifiable credential.
 
 ### What attribute types are available?
 
@@ -225,9 +246,9 @@ Example of schema source with all the types:
 
 ```
 
-### Issuing a VC
+## Issuing a VC
 
-1 Create a json file with credential subject matching the corresponding schema.
+### 1 Create a json file with credential subject matching the corresponding schema.
 (refer to properties->credential subject of the schema to figure out the json structure)
 
 Example for https://schema.affinidi.com/EventElegibilityV1-0.json:
@@ -243,7 +264,7 @@ Example for https://schema.affinidi.com/EventElegibilityV1-0.json:
 }
 ```
 
-2 Run the command:
+### 2 Run the command:
 
 ```
 affinidi issue-vc <holder-email@example.com> -s=<Schema Url> -d=credential.json -w=<path to holder wallet>
@@ -254,7 +275,7 @@ where
  - Schema Url - schema url, example: https://schema.affinidi.com/EventElegibilityV1-0.json
  - `<path to holder wallet>` - path to web UI of holder wallet, example: https://holder-reference-app.stg.affinidi.com/holder/
 
-## Usage
+## CLI Commands
 
 ## affinidi generate-application
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,210 @@ affinidi create project
 affinidi generate-application -n "My application"
 ```
 
+## Schema manager
+
+### What is Schema manager?
+
+If you want to build an app using Affinidi components, you should start here.
+Schema Manager helps you to find the right schema for your verifiable credential
+or to create a new one - either on the basis of an already existing schema,
+or completely from scratch.
+
+### How to use Schema manager?
+
+Schema Manager provides URLs for two kinds of schema representations:
+JSON Schema and JSON-LD context.
+Any schema can be referenced in a verifiable credentials or an application by these URLs.
+
+Before creating a new schema for your verifiable credentials,
+it is recommended to search for an existing one, which may fit your purpose.
+There are both a number of standard schemas and some user-generated schemas
+already available in the Schema Manager for your disposal,
+and you can search for them by “Credential schema type”.
+That is why it is important to provide a meaningful and expressive type
+for your newly created schemas.
+
+### What is the difference between a version and a revision?
+
+Essentially, all the revisions of the single version should be compatible with each other,
+whereas new versions could feature breaking changes, e.g. new mandatory fields.
+
+Currently, adherence to this principle is not enforced,
+but it is good to keep in mind when choosing between new version or revision for your forked schema.
+
+### What does it mean to “publish as searchable schema”?
+
+Schemas can be either public (visible and searchable for everyone ) or
+private (unlisted, visible and searchable only for you).
+When you “publish as searchable schema” (using flag `-p`), you make your schema public.
+
+It is important to remember, that versions and revisions of public and private
+(unlisted) schema are independent of each other,
+and are maintained by the system in parallel.
+However, you can always fork your private (unlisted) schema in order to make it public and vice versa.
+
+### How to create a schema
+
+1 Prepare a json file with schema details:
+
+```
+{
+  "type": "object",
+  "properties": {
+    "<propertyName>": {
+      "title": "<Property title>",
+      "type": "<Property type (see available attribites below)>",
+      "description": "<Property description>"
+    },
+    <other properties>
+  },
+  "required": [
+    <list of required properties>
+  ]
+}
+
+```
+Example:
+```
+{
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "title": "First Name",
+      "type": "string",
+      "description": "First name of a customer"
+    },
+    "lastName": {
+      "title": "Last Name",
+      "type": "string",
+      "description": "Last name of a customer"
+    }
+  },
+  "required": [
+    "lastName"
+  ]
+}
+```
+
+2 Run a command:
+
+```
+affinidi create schema -d <Description of your schema> -p=<true if private, false id public) -s=<schema.json>
+```
+
+3 In the response you will receive "jsonSchemaUrl" which you should use to issue a verifiable credential.
+
+### What attribute types are available?
+
+- Nested attribute – a container for attributes
+- DID – a decentralized identifier
+  - Example of VC value: "did:example:123"
+- Text – a string value
+  - Example of VC value: "my text"
+- URI – a link to a web resource
+  - Example of VC value: "http://ui.schema.affinidi.com/"
+- Date – a date (ISO 8601)
+  - Example of VC value: "2011-04-01"
+- DateTime – a specific point in time (ISO 8601)
+  - Example of VC value: "2011-05-08T19:30"
+- Number – a numerical value
+  - Example of VC value: 123.45
+- Boolean – a boolean value
+  - Example of VC value: true or false
+
+Example of schema source with all the types:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "nestedType": {
+            "title": "nestedType",
+            "type": "object",
+            "description": "Field with nested attributes",
+            "properties": {
+                "nestedTextType": {
+                    "title": "nestedTextType",
+                    "type": "string",
+                    "description": "Nested text field "
+                }
+            },
+            "required": []
+        },
+        "didType": {
+            "title": "didType",
+            "type": "string",
+            "format": "did",
+            "description": "DID attribute"
+        },
+        "testType": {
+            "title": "testType",
+            "type": "string",
+            "description": "Text attribute"
+        },
+        "uriType": {
+            "title": "uriType",
+            "type": "string",
+            "format": "uri",
+            "description": "URI attribute"
+        },
+        "dateType": {
+            "title": "dateType",
+            "type": "string",
+            "format": "date",
+            "description": "Date attribute"
+        },
+        "dateTimeType": {
+            "title": "dateTimeType",
+            "type": "string",
+            "format": "date-time",
+            "description": "DateTime attribute"
+        },
+        "numberType": {
+            "title": "numberType",
+            "type": "number",
+            "description": "Number attribute"
+        },
+        "booleanType": {
+            "title": "booleanType",
+            "type": "boolean",
+            "description": "Boolean attribute"
+        }
+    },
+    "required": []
+}
+
+```
+
+### Issuing a VC
+
+1 Create a json file with credential subject matching the corresponding schema.
+(refer to properties->credential subject of the schema to figure out the json structure)
+
+Example for https://schema.affinidi.com/EventElegibilityV1-0.json:
+
+```
+{
+    "date": "2031-12-11T11:15:00Z",
+    "place": "Awesome Location",
+    "eventName": "Name of Your Event",
+    "eventDescription": "Your Event Description",
+    "name": "Holder Name",
+    "email": "mail@example.com"
+}
+```
+
+2 Run the command:
+
+```
+affinidi issue-vc <holder-email@example.com> -s=<Schema Url> -d=credential.json -w=<path to holder wallet>
+```
+
+where
+ - holder-email - email, where a holder will receive a link to VC offer
+ - Schema Url - schema url, example: https://schema.affinidi.com/EventElegibilityV1-0.json
+ - `<path to holder wallet>` - path to web UI of holder wallet, example: https://holder-reference-app.stg.affinidi.com/holder/
+
 ## Usage
 
 ## affinidi generate-application

--- a/src/commands/create/schema.ts
+++ b/src/commands/create/schema.ts
@@ -32,7 +32,8 @@ export default class Schema extends Command {
 
   static usage = 'create schema [schemaName] [FLAGS]'
 
-  static description = 'Use this command to create a new Schema for your verifiable credential.'
+  static description =
+    'Use this command to create a new Schema for your verifiable credential. Refer to https://github.com/affinidi/affinidi-cli/blob/main/README.md#schema-manager for more details and examples.'
 
   static flags = {
     public: Flags.enum<'true' | 'false'>({

--- a/src/commands/issue-vc.ts
+++ b/src/commands/issue-vc.ts
@@ -28,12 +28,18 @@ export default class IssueVc extends Command {
 
   static usage = 'issue-vc [email] [FLAGS]'
 
-  static description = 'Issues a verifiable credential based on an given schema.'
+  static description =
+    'Issues a verifiable credential based on an given schema. Refer to https://github.com/affinidi/affinidi-cli/blob/main/README.md#issuing-a-vc for more details and examples.'
 
   static examples = ['<%= config.bin %> <%= command.id %>']
 
   static flags = {
-    schema: Flags.string({ char: 's', description: 'json schema url', required: true }),
+    schema: Flags.string({
+      char: 's',
+      description:
+        'json schema url. Example: https://schema.affinidi.com/EventElegibilityV1-0.json',
+      required: true,
+    }),
     data: Flags.string({
       char: 'd',
       description: 'the source file with credential data, either .json or .csv',


### PR DESCRIPTION
# Context:

Affinidi builders should have clear and comprehensive instructions how to create a schema and issue a VC with CLI.

This PR is mandatory to prepare CLI for usability testing.


# This PR:

- adds one more step to Quick Start section, describing how to issue a VC for "certification and verification" use case
  https://github.com/affinidi/affinidi-cli/blob/updated_docs/README.md#issue-a-vc-for-an-example-schema
- adds a new Section how to create a new schema with all the context and details
  https://github.com/affinidi/affinidi-cli/blob/updated_docs/README.md#schema-manager
- adds a new Section how to issue a VC for any schema.
  https://github.com/affinidi/affinidi-cli/blob/updated_docs/README.md#issuing-a-vc
- extends descriptions of the corresponding commands.  
  