### PR TITLE
fix: consistently use user-id instead of user-sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,20 +412,17 @@ _See code: [@oclif/plugin-commands](https://github.com/oclif/plugin-commands/blo
 
 ## `affinidi generate app`
 
-Generates a NextJS reference application that integrates Affinidi Login. Requires git
+Generates a reference application that integrates Affinidi Login. Requires git
 
 ```
 USAGE
-  $ affinidi generate app [--json] [--no-color] [--no-input] [-f django|nextjs] [-a affinidi|auth0] [-p <value>]
-    [--force]
+  $ affinidi generate app [--json] [--no-color] [--no-input] [-f <value>] [-a <value>] [-p <value>] [--force]
 
 FLAGS
-  -a, --provider=<option>   Authentication provider for the reference app
-                            <options: affinidi|auth0>
-  -f, --framework=<option>  Framework for the reference app
-                            <options: django|nextjs>
-  -p, --path=<value>        Relative or absolute path where reference application should be cloned into
-  --force                   Override destination directory if exists
+  -a, --provider=<value>   Authentication provider for the reference app
+  -f, --framework=<value>  Framework for the reference app
+  -p, --path=<value>       Relative or absolute path where reference application should be cloned into
+  --force                  Override destination directory if exists
 
 GLOBAL FLAGS
   --json      Format output as json.
@@ -466,12 +463,12 @@ Adds a principal (user or token) to the active project
 
 ```
 USAGE
-  $ affinidi iam add-principal [--json] [--no-color] [--no-input] [-i <value>] [-t machine_user|user]
+  $ affinidi iam add-principal [--json] [--no-color] [--no-input] [-i <value>] [-t token|user]
 
 FLAGS
   -i, --principal-id=<value>     ID of the principal
   -t, --principal-type=<option>  Type of the principal
-                                 <options: machine_user|user>
+                                 <options: token|user>
 
 GLOBAL FLAGS
   --json      Format output as json.
@@ -486,7 +483,7 @@ DESCRIPTION
 EXAMPLES
   $ affinidi iam add-principal -i <uuid>
 
-  $ affinidi iam add-principal --principal-id <uuid> --principal-type machine_user
+  $ affinidi iam add-principal --principal-id <uuid> --principal-type token
 
 FLAG DESCRIPTIONS
   -i, --principal-id=<value>  ID of the principal
@@ -500,12 +497,12 @@ Gets the policies of a principal (user or token)
 
 ```
 USAGE
-  $ affinidi iam get-policies [--json] [--no-color] [--no-input] [-i <value>] [-t machine_user|user]
+  $ affinidi iam get-policies [--json] [--no-color] [--no-input] [-i <value>] [-t token|user]
 
 FLAGS
   -i, --principal-id=<value>     ID of the principal
   -t, --principal-type=<option>  Type of the principal
-                                 <options: machine_user|user>
+                                 <options: token|user>
 
 GLOBAL FLAGS
   --json      Format output as json.
@@ -521,7 +518,7 @@ DESCRIPTION
 EXAMPLES
   $ affinidi iam get-policies -i <uuid>
 
-  $ affinidi iam get-policies --principal-id <uuid> --principal-type machine_user
+  $ affinidi iam get-policies --principal-id <uuid> --principal-type token
 
 FLAG DESCRIPTIONS
   -i, --principal-id=<value>  ID of the principal
@@ -557,12 +554,12 @@ Removes a principal (user or token) from the active project
 
 ```
 USAGE
-  $ affinidi iam remove-principal [--json] [--no-color] [--no-input] [-i <value>] [-t machine_user|user]
+  $ affinidi iam remove-principal [--json] [--no-color] [--no-input] [-i <value>] [-t token|user]
 
 FLAGS
   -i, --principal-id=<value>     ID of the principal
   -t, --principal-type=<option>  Type of the principal
-                                 <options: machine_user|user>
+                                 <options: token|user>
 
 GLOBAL FLAGS
   --json      Format output as json.
@@ -577,7 +574,7 @@ DESCRIPTION
 EXAMPLES
   $ affinidi iam remove-principal -i <uuid>
 
-  $ affinidi iam remove-principal --principal-id <uuid> --principal-type machine_user
+  $ affinidi iam remove-principal --principal-id <uuid> --principal-type token
 
 FLAG DESCRIPTIONS
   -i, --principal-id=<value>  ID of the principal
@@ -591,13 +588,13 @@ Updates the policies of a principal (user or token) in the active project
 
 ```
 USAGE
-  $ affinidi iam update-policies [--json] [--no-color] [--no-input] [-i <value>] [-t machine_user|user] [-f <value>]
+  $ affinidi iam update-policies [--json] [--no-color] [--no-input] [-i <value>] [-t token|user] [-f <value>]
 
 FLAGS
   -f, --file=<value>             Location of a json file containing principal policies
   -i, --principal-id=<value>     ID of the principal
   -t, --principal-type=<option>  Type of the principal
-                                 <options: machine_user|user>
+                                 <options: token|user>
 
 GLOBAL FLAGS
   --json      Format output as json.
@@ -613,7 +610,7 @@ DESCRIPTION
 EXAMPLES
   $ affinidi iam update-policies -i <uuid>
 
-  $ affinidi iam update-policies --principal-id <uuid> --principal-type machine_user --file policies.json
+  $ affinidi iam update-policies --principal-id <uuid> --principal-type token --file policies.json
 
 FLAG DESCRIPTIONS
   -i, --principal-id=<value>  ID of the principal
@@ -627,11 +624,11 @@ Adds a user to a user group
 
 ```
 USAGE
-  $ affinidi login add-user-to-group [--json] [--no-color] [--no-input] [--group-name <value>] [--user-sub <value>]
+  $ affinidi login add-user-to-group [--json] [--no-color] [--no-input] [--group-name <value>] [--user-id <value>]
 
 FLAGS
   --group-name=<value>  Name of the user group
-  --user-sub=<value>    Subject of the user. Currently the user's DID is supported.
+  --user-id=<value>     Id of the user. Currently the user's DID is supported.
 
 GLOBAL FLAGS
   --json      Format output as json.
@@ -639,7 +636,7 @@ GLOBAL FLAGS
   --no-input  Disables all the interactive prompts
 
 EXAMPLES
-  $ affinidi login add-user-to-group --group-name my_group --user-sub did:key:12345
+  $ affinidi login add-user-to-group --group-name my_group --user-id did:key:12345
 ```
 
 ## `affinidi login create-config`
@@ -861,12 +858,11 @@ Removes a user from a user group
 
 ```
 USAGE
-  $ affinidi login remove-user-from-group [--json] [--no-color] [--no-input] [--group-name <value>] [--user-mapping-id
-  <value>]
+  $ affinidi login remove-user-from-group [--json] [--no-color] [--no-input] [--group-name <value>] [--user-id <value>]
 
 FLAGS
-  --group-name=<value>       Name of the user group
-  --user-mapping-id=<value>  ID of the user mapping record
+  --group-name=<value>  Name of the user group
+  --user-id=<value>     ID of the user
 
 GLOBAL FLAGS
   --json      Format output as json.
@@ -874,7 +870,7 @@ GLOBAL FLAGS
   --no-input  Disables all the interactive prompts
 
 EXAMPLES
-  $ affinidi login remove-user-from-group --group-name my_group --user-mapping-id <value>
+  $ affinidi login remove-user-from-group --group-name my_group --user-id did:key:12345
 ```
 
 ## `affinidi login update-config`
@@ -1037,7 +1033,7 @@ EXAMPLES
   $ affinidi start
 ```
 
-_See code: [dist/commands/start.ts](https://github.com/affinidi/affinidi-cli/blob/v2.0.0-beta.8/dist/commands/start.ts)_
+_See code: [dist/commands/start.ts](https://github.com/affinidi/affinidi-cli/blob/v2.0.0-beta.10/dist/commands/start.ts)_
 
 ## `affinidi stop`
 
@@ -1056,7 +1052,7 @@ EXAMPLES
   $ affinidi stop
 ```
 
-_See code: [dist/commands/stop.ts](https://github.com/affinidi/affinidi-cli/blob/v2.0.0-beta.8/dist/commands/stop.ts)_
+_See code: [dist/commands/stop.ts](https://github.com/affinidi/affinidi-cli/blob/v2.0.0-beta.10/dist/commands/stop.ts)_
 
 ## `affinidi token create-token`
 
@@ -1191,5 +1187,5 @@ EXAMPLES
   $ affinidi whoami
 ```
 
-_See code: [dist/commands/whoami.ts](https://github.com/affinidi/affinidi-cli/blob/v2.0.0-beta.8/dist/commands/whoami.ts)_
+_See code: [dist/commands/whoami.ts](https://github.com/affinidi/affinidi-cli/blob/v2.0.0-beta.10/dist/commands/whoami.ts)_
 <!-- commandsstop -->

--- a/src/commands/generate/app.ts
+++ b/src/commands/generate/app.ts
@@ -32,12 +32,10 @@ export default class GenerateApp extends BaseCommand<typeof GenerateApp> {
     framework: Flags.string({
       char: 'f',
       summary: 'Framework for the reference app',
-      options: [],
     }),
     provider: Flags.string({
       char: 'a',
       summary: 'Authentication provider for the reference app',
-      options: [],
     }),
     path: Flags.string({
       char: 'p',

--- a/src/commands/login/add-user-to-group.ts
+++ b/src/commands/login/add-user-to-group.ts
@@ -8,29 +8,29 @@ import { GroupUserMappingDto } from '../../services/affinidi/vp-adapter/vp-adapt
 
 export class AddUserToGroup extends BaseCommand<typeof AddUserToGroup> {
   static summary = 'Adds a user to a user group'
-  static examples = ['<%= config.bin %> <%= command.id %> --group-name my_group --user-sub did:key:12345']
+  static examples = ['<%= config.bin %> <%= command.id %> --group-name my_group --user-id did:key:12345']
   static flags = {
     'group-name': Flags.string({
       summary: 'Name of the user group',
     }),
-    'user-sub': Flags.string({
-      summary: "Subject of the user. Currently the user's DID is supported.",
+    'user-id': Flags.string({
+      summary: "Id of the user. Currently the user's DID is supported.",
     }),
   }
 
   public async run(): Promise<GroupUserMappingDto> {
     const { flags } = await this.parse(AddUserToGroup)
-    const promptFlags = await promptRequiredParameters(['group-name', 'user-sub'], flags)
+    const promptFlags = await promptRequiredParameters(['group-name', 'user-id'], flags)
     const schema = z.object({
       'group-name': z.string().max(INPUT_LIMIT),
-      'user-sub': z.string().max(INPUT_LIMIT),
+      'user-id': z.string().max(INPUT_LIMIT),
     })
     const validatedFlags = schema.parse(promptFlags)
 
     ux.action.start('Adding user to group')
     const addUserToGroupOutput = await vpAdapterService.addUserToGroup(
       validatedFlags['group-name'],
-      validatedFlags['user-sub'],
+      validatedFlags['user-id'],
     )
     ux.action.stop('Added successfully!')
 

--- a/src/commands/login/remove-user-from-group.ts
+++ b/src/commands/login/remove-user-from-group.ts
@@ -7,17 +7,17 @@ import { vpAdapterService } from '../../services/affinidi/vp-adapter'
 
 export class RemoveUserFromGroup extends BaseCommand<typeof RemoveUserFromGroup> {
   static summary = 'Removes a user from a user group'
-  static examples = ['<%= config.bin %> <%= command.id %> --group-name my_group --user-id <value>']
+  static examples = ['<%= config.bin %> <%= command.id %> --group-name my_group --user-id did:key:12345']
   static flags = {
     'group-name': Flags.string({
       summary: 'Name of the user group',
     }),
     'user-id': Flags.string({
-      summary: 'ID of the user mapping record',
+      summary: 'ID of the user',
     }),
   }
 
-  public async run(): Promise<{ groupName: string; userMappingId: string }> {
+  public async run(): Promise<{ groupName: string; userId: string }> {
     const { flags } = await this.parse(RemoveUserFromGroup)
     const promptFlags = await promptRequiredParameters(['group-name', 'user-id'], flags)
     const schema = z.object({
@@ -30,7 +30,7 @@ export class RemoveUserFromGroup extends BaseCommand<typeof RemoveUserFromGroup>
     await vpAdapterService.removeUserFromGroup(validatedFlags['group-name'], validatedFlags['user-id'])
     ux.action.stop('Removed successfully!')
 
-    const response = { groupName: validatedFlags['group-name'], userMappingId: validatedFlags['user-id'] }
+    const response = { groupName: validatedFlags['group-name'], userId: validatedFlags['user-id'] }
     if (!this.jsonEnabled()) this.logJson(response)
     return response
   }

--- a/test/commands/login/users-of-groups.test.ts
+++ b/test/commands/login/users-of-groups.test.ts
@@ -5,8 +5,7 @@ const VP_ADAPTER_URL = `${config.bffHost}/vpa`
 
 const data = {
   existingGroupName: 'existing-group-name',
-  newUserSub: 'did:key:12345',
-  userGroupMappingId: 'bbbfb63cfa8d17a01b8e9ef491caf049a162c5a41b5d322835f9f6ff9dfce6f2',
+  newUserId: 'did:key:12345',
 }
 
 describe('login: group users commands', function () {
@@ -14,30 +13,22 @@ describe('login: group users commands', function () {
     const validArgs = [
       'login:add-user-to-group',
       `--group-name=${data.existingGroupName}`,
-      `--user-sub=${data.newUserSub}`,
+      `--user-id=${data.newUserId}`,
     ]
 
     test
       .nock(VP_ADAPTER_URL, (api) =>
         api.post(`/v1/groups/${data.existingGroupName}/users`).reply(200, {
-          ari: 'ari:identity:ap-southeast-1:1afac523-9ed4-4b72-af29-16c376b5a32a:group/existing-group-name/user/85556da4ac2238ceb4ab0355aaa36fb7a5eb7459fade25f7d96b8f3a6e1c1023',
-          projectId: '1afac523-9ed4-4b72-af29-16c376b5a32a',
-          groupName: 'existing-group-name',
-          sub: 'did:key:12345',
-          id: '85556da4ac2238ceb4ab0355aaa36fb7a5eb7459fade25f7d96b8f3a6e1c1023',
-          creationDate: '2023-09-22T06:20:56.372Z',
+          userId: 'did:key:12345',
+          addedAt: '2023-09-22T06:20:56.372Z',
         }),
       )
       .stdout()
       .command(validArgs)
       .it('outputs the user and group info', async (ctx) => {
         const response = JSON.parse(ctx.stdout)
-        expect(response).to.have.a.property('ari')
-        expect(response).to.have.a.property('groupName')
-        expect(response).to.have.a.property('sub')
-        expect(response).to.have.a.property('id')
-        expect(response).to.have.a.property('projectId')
-        expect(response).to.have.a.property('creationDate')
+        expect(response).to.have.a.property('userId')
+        expect(response).to.have.a.property('addedAt')
       })
   })
 
@@ -49,12 +40,8 @@ describe('login: group users commands', function () {
         api.get(`/v1/groups/${data.existingGroupName}/users`).reply(200, {
           users: [
             {
-              ari: 'ari:identity:ap-southeast-1:1afac523-9ed4-4b72-af29-16c376b5a32a:group/existing-group-name/user/85556da4ac2238ceb4ab0355aaa36fb7a5eb7459fade25f7d96b8f3a6e1c1023',
-              projectId: '1afac523-9ed4-4b72-af29-16c376b5a32a',
-              groupName: 'existing-group-name',
-              sub: 'did:key:12345',
-              id: '85556da4ac2238ceb4ab0355aaa36fb7a5eb7459fade25f7d96b8f3a6e1c1023',
-              creationDate: '2023-09-22T06:20:56.372Z',
+              userId: 'did:key:12345',
+              addedAt: '2023-09-22T06:20:56.372Z',
             },
           ],
         }),
@@ -64,12 +51,8 @@ describe('login: group users commands', function () {
       .it('outputs the user and group info', async (ctx) => {
         const response = JSON.parse(ctx.stdout)
         expect(response).to.have.a.property('users')
-        expect(response.users[0]).to.have.a.property('ari')
-        expect(response.users[0]).to.have.a.property('groupName')
-        expect(response.users[0]).to.have.a.property('sub')
-        expect(response.users[0]).to.have.a.property('id')
-        expect(response.users[0]).to.have.a.property('projectId')
-        expect(response.users[0]).to.have.a.property('creationDate')
+        expect(response.users[0]).to.have.a.property('userId')
+        expect(response.users[0]).to.have.a.property('addedAt')
       })
   })
 
@@ -77,13 +60,13 @@ describe('login: group users commands', function () {
     const validArgs = [
       'login:remove-user-from-group',
       `--group-name=${data.existingGroupName}`,
-      `--user-id=${data.userGroupMappingId}`,
+      `--user-id=${data.newUserId}`,
     ]
 
     test
       .nock(VP_ADAPTER_URL, (api) =>
         api.delete(`/v1/groups/${data.existingGroupName}/users`).reply(200, {
-          userId: data.userGroupMappingId,
+          userId: data.newUserId,
         }),
       )
       .stdout()
@@ -91,7 +74,7 @@ describe('login: group users commands', function () {
       .it('outputs the user and group info', async (ctx) => {
         const response = JSON.parse(ctx.stdout)
         expect(response).to.have.a.property('groupName')
-        expect(response).to.have.a.property('userMappingId')
+        expect(response).to.have.a.property('userId')
       })
   })
 })


### PR DESCRIPTION
- Consistently use `user-id` instead of `user-sub`
- Removed options from `generate app`
- Updated readme