### PR TITLE
Adding capability to create a mobile app with frontend and backend repos

### DIFF
--- a/src/commands/generate/app.ts
+++ b/src/commands/generate/app.ts
@@ -14,7 +14,7 @@ import { createAuth0Resources } from '../../services/generator/auth0'
 import { configureAppEnvironment } from '../../services/generator/env-configurer'
 
 const APPS_INFORMATION_GITHUB_LOCATION = 'samples/apps.json'
-const APPS_GITHUB_LOCATION = 'affinidi/reference-app-affinidi-vault/samples'
+const APPS_GITHUB_LOCATION = 'affinidi/reference-app-affinidi-vault/samples?ref=flutter_mobile_app'
 
 export default class GenerateApp extends BaseCommand<typeof GenerateApp> {
   static apps: AppsInformation
@@ -115,7 +115,7 @@ export default class GenerateApp extends BaseCommand<typeof GenerateApp> {
 
       ux.action.start('Generating sample app')
 
-      await cloneWithDegit(`${APPS_GITHUB_LOCATION}/${appName}`, validatedFlags.path, flags.force)
+      await cloneWithDegit(`${APPS_GITHUB_LOCATION}/${appName}#flutter_mobile_app`, validatedFlags.path, flags.force)
 
       ux.action.stop('Generated successfully!')
 

--- a/src/services/generator/env-configurer.ts
+++ b/src/services/generator/env-configurer.ts
@@ -7,6 +7,7 @@ export async function configureAppEnvironment(
   issuer: string,
   connectionName?: string,
 ) {
+  console.log(`Path: ${path}`)
   const donEnv = `${path}/.env`
   const donEnvExample = `${path}/.env.example`
 


### PR DESCRIPTION
Added additional flag '--mobile' boolean inorder to allow for environment file to be copied into two locations
- frontend/.env
- backend/.env

For mobile apps, we need both frontend and backend repos to complete the PKCE auth flow in a secure way