### PR TITLE
feat: improved create token command

### DIFF
--- a/docs/start.md
+++ b/docs/start.md
@@ -22,4 +22,4 @@ EXAMPLES
   $ affinidi start
 ```
 
-_See code: [dist/commands/start.ts](https://github.com/affinidi/affinidi-cli/blob/v2.4.0/dist/commands/start.ts)_
+_See code: [dist/commands/start.ts](https://github.com/affinidi/affinidi-cli/blob/v2.5.0/dist/commands/start.ts)_

--- a/docs/stop.md
+++ b/docs/stop.md
@@ -22,4 +22,4 @@ EXAMPLES
   $ affinidi stop
 ```
 
-_See code: [dist/commands/stop.ts](https://github.com/affinidi/affinidi-cli/blob/v2.4.0/dist/commands/stop.ts)_
+_See code: [dist/commands/stop.ts](https://github.com/affinidi/affinidi-cli/blob/v2.5.0/dist/commands/stop.ts)_

--- a/docs/token.md
+++ b/docs/token.md
@@ -15,18 +15,18 @@ Creates a Personal Access Token (PAT)
 
 ```
 USAGE
-  $ affinidi token create-token [--json] [--no-color] [--no-input] [-n <value>] [-k <value>] [-f <value>] [-a
-    RS256|RS512|ES256|ES512] [-w] [-p <value>]
+  $ affinidi token create-token [--json] [--no-color] [--no-input] [-n <value>] [-k <value>] [-a
+    RS256|RS512|ES256|ES512] [-w] [-p <value> [-g | -f <value>]]
 
 FLAGS
   -a, --algorithm=<option>       [default: RS256] The specific cryptographic algorithm used with the key
                                  <options: RS256|RS512|ES256|ES512>
   -f, --public-key-file=<value>  Location of the public key PEM file
+  -g, --auto-generate-key        Auto-generate private-public key pair
   -k, --key-id=<value>           Identifier of the key (kid)
   -n, --name=<value>             Name of the Personal Access Token, at least 8 chars long
   -p, --passphrase=<value>       Passphrase for generation of private public key pair
-  -w, --with-permissions         Create ready-to-use PAT with auto-generated private public key pair and set its access
-                                 policies
+  -w, --with-permissions         Set token policies to perform any action on the active project
 
 GLOBAL FLAGS
   --json      Format output as json.
@@ -34,13 +34,19 @@ GLOBAL FLAGS
   --no-input  Disables all the interactive prompts
 
 EXAMPLES
-  $ affinidi token create-token -n MyNewToken -w -p top-secret
+  $ affinidi token create-token
 
-  $ affinidi token create-token --name MyNewToken --with-permissions --passphrase top-secret
+  $ affinidi token create-token --name "My new token"
 
-  $ affinidi token create-token -n MyNewToken -k MyKeyID -f publicKey.pem
+  $ affinidi token create-token -n MyNewToken --with-permissions
 
-  $ affinidi token create-token --name "My new token" --key-id MyKeyID --public-key-file publicKey.pem --algorithm RS256
+  $ affinidi token create-token -n MyNewToken --auto-generate-key
+
+  $ affinidi token create-token -n MyNewToken --auto-generate-key --passphrase "MySecretPassphrase" --with-permissions
+
+  $ affinidi token create-token -n MyNewToken --public-key-file publicKey.pem --key-id MyKeyID --algorithm RS256 --with-permissions
+
+  $ affinidi token create-token -n MyNewToken -g -w
 ```
 
 ## `affinidi token delete-token`

--- a/docs/whoami.md
+++ b/docs/whoami.md
@@ -22,4 +22,4 @@ EXAMPLES
   $ affinidi whoami
 ```
 
-_See code: [dist/commands/whoami.ts](https://github.com/affinidi/affinidi-cli/blob/v2.4.0/dist/commands/whoami.ts)_
+_See code: [dist/commands/whoami.ts](https://github.com/affinidi/affinidi-cli/blob/v2.5.0/dist/commands/whoami.ts)_

--- a/src/commands/token/create-token.ts
+++ b/src/commands/token/create-token.ts
@@ -1,5 +1,7 @@
+import { KeyExportOptions } from 'crypto'
 import { readFile } from 'fs/promises'
 import { generateKeyPairSync } from 'node:crypto'
+import { confirm, input } from '@inquirer/prompts'
 import { Flags, ux } from '@oclif/core'
 import { v4 as uuidv4 } from 'uuid'
 import { z } from 'zod'
@@ -10,8 +12,6 @@ import { getKeyType, pemToJWK } from '../../helpers/jwk'
 import { bffService } from '../../services/affinidi/bff-service'
 import { iamService } from '../../services/affinidi/iam'
 import { TokenDto, JsonWebKeySetDto } from '../../services/affinidi/iam/iam.api'
-import { confirm, input } from '@inquirer/prompts'
-import { KeyExportOptions } from 'crypto'
 
 const flagsSchema = z
   .object({
@@ -165,7 +165,7 @@ export class CreateToken extends BaseCommand<typeof CreateToken> {
     }
 
     if (promptFlags['auto-generate-key'] && !promptFlags['no-input']) {
-      promptFlags['passphrase'] = validateInputLength(
+      promptFlags.passphrase = validateInputLength(
         await input({
           message: 'Enter a passphrase to encrypt the private key. Leave it empty for no encryption',
         }),
@@ -185,14 +185,14 @@ export class CreateToken extends BaseCommand<typeof CreateToken> {
     }
 
     if (!promptFlags['no-input'] && promptFlags['with-permissions']) {
-      promptFlags['resources'] = validateInputLength(
+      promptFlags.resources = validateInputLength(
         await input({
           message: 'Enter the allowed resources, separated by spaces. Use * to allow access to all project resources',
           default: '*',
         }),
         INPUT_LIMIT,
       )
-      promptFlags['actions'] = validateInputLength(
+      promptFlags.actions = validateInputLength(
         await input({
           message: 'Enter the allowed actions, separated by spaces. Use * to allow all actions',
           default: '*',

--- a/src/common/validators.ts
+++ b/src/common/validators.ts
@@ -1,4 +1,5 @@
 import { CLIError } from '@oclif/core/lib/errors'
+import z from 'zod'
 
 export const INPUT_LIMIT = 2000
 export const TOKEN_LIMIT = 5000
@@ -15,3 +16,16 @@ export function validateInputLength(text: string, maxLength: number): string {
 export function split(text: string, delimiter: string): string[] {
   return text.split(delimiter).filter((item) => item.length > 0)
 }
+
+export const policiesDataSchema = z.object({
+  version: z.string().max(INPUT_LIMIT),
+  statement: z
+    .object({
+      principal: z.string().max(INPUT_LIMIT).array().length(1),
+      action: z.string().max(INPUT_LIMIT).array().nonempty(),
+      resource: z.string().max(INPUT_LIMIT).array().nonempty(),
+      effect: z.literal('Allow'),
+    })
+    .array()
+    .nonempty(),
+})

--- a/test/commands/token/token.test.ts
+++ b/test/commands/token/token.test.ts
@@ -3,13 +3,11 @@ import { config } from '../../../src/services/env-config'
 
 const IAM_URL = `${config.bffHost}/iam`
 
-const tokenId = 'c4a32776-3203-4bf7-87d9-a6e6f9ddd09e'
-
 const data = {
   newTokenName: 'new-token-name',
   keyId: '12345',
   publicKeyFilePath: 'test/helpers/public_key.pem',
-  tokenId,
+  tokenId: 'c4a32776-3203-4bf7-87d9-a6e6f9ddd09e',
   passphrase: 'top-secret',
 }
 
@@ -20,6 +18,8 @@ describe('login: token management commands', function () {
       `--name=${data.newTokenName}`,
       `--key-id=${data.keyId}`,
       `--public-key-file=${data.publicKeyFilePath}`,
+      '--no-input',
+      '--json',
     ]
 
     test
@@ -63,12 +63,15 @@ describe('login: token management commands', function () {
       })
   })
 
-  describe('token:create-token with-permissions', () => {
+  describe('token:create-token with-permissions auto-generate-key', () => {
     const validArgs = [
       'token:create-token',
       `--name=${data.newTokenName}`,
+      `--public-key-file=${data.publicKeyFilePath}`,
+      `--key-id=${data.keyId}`,
       `--with-permissions`,
-      `--passphrase=${data.passphrase}`,
+      '--no-input',
+      `--json`,
     ]
 
     const getPoliciesApiResponse = {
@@ -86,7 +89,7 @@ describe('login: token management commands', function () {
     test
       .nock(IAM_URL, (api) =>
         api.post('/v1/tokens').reply(200, {
-          id: tokenId,
+          id: data.tokenId,
           ari: 'ari:iam:::user/2f4b3468-516f-4af3-87db-8816b0d320cc',
           ownerAri: 'AIV/Concierge API - affinidi-elements-iam-dev',
           name: 'test',
@@ -99,7 +102,7 @@ describe('login: token management commands', function () {
                   {
                     use: 'sig',
                     kty: 'RSA',
-                    kid: '12345',
+                    kid: data.tokenId,
                     alg: 'RS256',
                     n: '3CNY1aZmssMdh2dGKJpGki_BD5URuW8ngNMkZhJ1ux9X6vjng3XMLnvY2yTm3ucnEfl_XDLXE6K0wIt_1z2aGf-Kq1okCivnKv6DS1afX8J-ewvS-TnKTNFrtX9fRHxdBp2Pah144niZxScJKWhBQDjtrNJOEk-JpEkp-6MzvEQ-pac2_7ZyEAnWncQ8ncR_liYgxGj5ZQ6q2md-Gkk6dxmAe3W2oQPNOMqOtVUkQ1u79e8pmdgVEnuTJ2vdoyWaXmQBHsSISEHozaxjgf5wKiGy0K1aT30pfxzGy9xGdNAVj7g9lUoPRqfk-Sz4Uyy4osCn8jVqkrAmypTPVb_PFQ',
                     e: 'AQAB',
@@ -112,24 +115,21 @@ describe('login: token management commands', function () {
         }),
       )
       .nock(IAM_URL, (api) => api.post('/v1/projects/principals').reply(200))
-      .nock(IAM_URL, (api) =>
-        api.get(`/v1/policies/principals/${tokenId}?principalType=token`).reply(200, getPoliciesApiResponse),
-      )
-      .nock(IAM_URL, (api) => api.put(`/v1/policies/principals/${tokenId}?principalType=token`).reply(200))
+      .nock(IAM_URL, (api) => api.put(`/v1/policies/principals/${data.tokenId}?principalType=token`).reply(200))
       .nock(config.bffHost, (api) => api.get('/api/project').reply(200, { id: '1234' }))
       .stdout()
+      .stderr()
       .command(validArgs)
       .it(
         'generates private public key pair used for token creation, updates policies, returns PAT variables for TDK',
         async (ctx) => {
           const response = JSON.parse(ctx.stdout)
-          expect(response).to.have.a.property('apiGatewayUrl')
-          expect(response).to.have.a.property('tokenEndpoint')
-          expect(response).to.have.a.property('keyId')
-          expect(response).to.have.a.property('tokenId')
-          expect(response).to.have.a.property('passphrase')
-          expect(response).to.have.a.property('privateKey')
-          expect(response).to.have.a.property('projectId')
+          expect(response).to.have.a.property('id')
+          expect(response).to.have.a.property('ari')
+          expect(response).to.have.a.property('ownerAri')
+          expect(response).to.have.a.property('name')
+          expect(response).to.have.a.property('scopes')
+          expect(response).to.have.a.property('authenticationMethod')
         },
       )
   })


### PR DESCRIPTION
- Separate the creation of key pair from the assigning of policies
- Make keyId optional and default to tokenId
- Improve create token command prompting and flag inputs
- Make passphrase truly optional, instead of encrypting with an empty passphrase