### PR TITLE
feat: FTL-17182 enable verification and consent logging in iota by default

### DIFF
--- a/docs/iota.md
+++ b/docs/iota.md
@@ -35,8 +35,8 @@ FLAGS
       --client-logo=<value>           Application URL of a logo, displayed in the consent page
       --client-name=<value>           Name, displayed in the consent page
       --client-origin=<value>         Domain, displayed in the consent page
-      --enable-consent-audit-log      Log consents
-      --enable-verification           Perform verification
+      --disable-consent-audit-log     Disable log consents
+      --disable-verification          Disable verification
       --response-webhook-url=<value>  Affinidi Iota Framework response webhook URL
       --token-max-age=<value>         Token expiration time in seconds
 
@@ -50,9 +50,9 @@ EXAMPLES
 
   $ affinidi iota create-config --name <value> --wallet-ari <value>
 
-  $ affinidi iota create-config --name <value> --wallet-ari <value> --enable-consent-audit-log --enable-verification --token-max-age <value> --mode websocket
+  $ affinidi iota create-config --name <value> --wallet-ari <value> --token-max-age <value> --mode websocket
 
-  $ affinidi iota create-config --name <value> --wallet-ari <value> --enable-consent-audit-log --enable-verification --token-max-age <value> --mode redirect --redirectUris <value>
+  $ affinidi iota create-config --name <value> --wallet-ari <value> --token-max-age <value> --mode redirect --redirectUris <value>
 ```
 
 _See code: [src/commands/iota/create-config.ts](https://github.com/affinidi/affinidi-cli/blob/v2.10.2/src/commands/iota/create-config.ts)_

--- a/src/commands/iota/create-config.ts
+++ b/src/commands/iota/create-config.ts
@@ -54,9 +54,19 @@ export class CreateIotaConfig extends BaseCommand<typeof CreateIotaConfig> {
     }),
     'enable-verification': Flags.boolean({
       summary: 'Perform verification',
+      hidden: true,
+      deprecated: { message: 'This flag is deprecated as verification is now enabled by default.' },
+    }),
+    'disable-verification': Flags.boolean({
+      summary: 'Disable verification',
       default: false,
     }),
     'enable-consent-audit-log': Flags.boolean({
+      summary: 'Log consents',
+      hidden: true,
+      deprecated: { message: 'This flag is deprecated as consent audit logging is now enabled by default.' },
+    }),
+    'disable-consent-audit-log': Flags.boolean({
       summary: 'Log consents',
       default: false,
     }),
@@ -197,8 +207,8 @@ export class CreateIotaConfig extends BaseCommand<typeof CreateIotaConfig> {
         redirectUris,
       }),
       iotaResponseWebhookURL: flags['response-webhook-url'] ?? '',
-      enableVerification: flags['enable-verification'] || false,
-      enableConsentAuditLog: flags['enable-consent-audit-log'] || false,
+      enableVerification: !flags['disable-verification'],
+      enableConsentAuditLog: !flags['disable-consent-audit-log'],
       tokenMaxAge: flags['token-max-age'] ?? undefined,
       clientMetadata: {
         name: flags['client-name'] ?? '',

--- a/src/commands/iota/create-config.ts
+++ b/src/commands/iota/create-config.ts
@@ -72,7 +72,7 @@ export class CreateIotaConfig extends BaseCommand<typeof CreateIotaConfig> {
   }
 
   public async run(): Promise<IotaConfigurationDto> {
-    const { flags } = await this.parse(CreateIotaConfig)
+    const flags = this.flags
 
     const MODE_REDIRECT = CreateIotaConfigurationInputModeEnum.Redirect
     const MODE_WEBSOCKET = CreateIotaConfigurationInputModeEnum.Websocket

--- a/test/commands/iota/configs.test.ts
+++ b/test/commands/iota/configs.test.ts
@@ -63,7 +63,7 @@ const configurationRedirect = {
 
 describe('iota: configs commands', function () {
   describe('iota:create-config', () => {
-    it('creates a `websocket` configutation and outputs its info', async () => {
+    it('creates a `websocket` configuration and outputs its info', async () => {
       nock(AIS_URL).post('/v1/configurations').reply(200, configurationWebsocket)
       nock(CWE_URL)
         .get('/v1/wallets')
@@ -76,8 +76,6 @@ describe('iota: configs commands', function () {
         `--mode="${configurationWebsocket.mode}"`,
         `--response-webhook-url="${configurationWebsocket.iotaResponseWebhookURL}"`,
         `--token-max-age="${configurationWebsocket.tokenMaxAge}"`,
-        `--enable-verification`,
-        `--enable-consent-audit-log`,
         `--client-name="${configurationWebsocket.clientMetadata.name}"`,
         `--client-logo="${configurationWebsocket.clientMetadata.logo}"`,
         `--client-origin="${configurationWebsocket.clientMetadata.origin}"`,
@@ -113,8 +111,6 @@ describe('iota: configs commands', function () {
         `--mode="${configurationRedirect.mode}"`,
         `--redirect-uris="${configurationRedirect.redirectUris.join(' ')}"`,
         `--token-max-age="${configurationRedirect.tokenMaxAge}"`,
-        `--enable-verification`,
-        `--enable-consent-audit-log`,
         `--client-name="${configurationRedirect.clientMetadata.name}"`,
         `--client-logo="${configurationRedirect.clientMetadata.logo}"`,
         `--client-origin="${configurationRedirect.clientMetadata.origin}"`,


### PR DESCRIPTION
Deprecates the flags `enable-verification` and `enable-consent-audit-log`
for the `iota create-config` command as they are not needed anymore. Both values
are set by default to enable verification and consent audit log.

Furthermore it introduces the following flags to optionally disable the options:
* `disable-verification`
* `disable-consent-audit-log`