### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/affinidi/affinidi-cli/security/code-scanning/8](https://github.com/affinidi/affinidi-cli/security/code-scanning/8)

Add an explicit workflow-level `permissions` block in `.github/workflows/checks.yml` so all jobs inherit least-privilege token access. The best minimal fix here is:

- `contents: read`

This supports `actions/checkout` while preventing unnecessary write access. Place the block at the top level (after `on:` and before `jobs:`), which avoids duplicating permissions across all jobs and preserves existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
